### PR TITLE
Fix erc20 contracts decimals overflow

### DIFF
--- a/abis/IERC20Metadata.json
+++ b/abis/IERC20Metadata.json
@@ -1,0 +1,233 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "IERC20Metadata",
+  "sourceName": "contracts/token/ERC20/extensions/IERC20Metadata.sol",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,5 +1,6 @@
 import {
 	Address,
+	BigDecimal,
 	log,
 } from '@graphprotocol/graph-ts'
 
@@ -34,19 +35,25 @@ import {
 const DEFAULT_DECIMALS = 18
 const MAX_DECIMALS = 36 // safe cap for BigDecimal math
 
-function normalizeDecimals(dec: i32): i32 {
-  if (dec < 0) return 0
-  if (dec > MAX_DECIMALS) {
-    log.warning('Capping absurd decimals {} to {}', [dec.toString(), MAX_DECIMALS.toString()])
-    return MAX_DECIMALS
-  }
-  return dec
-}
-
 export function fetchAccount(address: Address): Account {
 	let account = new Account(address)
 	account.save()
 	return account
+}
+
+export function fetchERC20Decimals(endpoint: IERC20): i32 {
+	let decimalsResult = endpoint.try_decimals();
+	if (decimalsResult.reverted) {
+		return DEFAULT_DECIMALS;
+	}
+
+	// Ignore any weird tokens to avoid overflowing the `decimals` field (which is an i32)
+	// On mainnet for example there is at least one token which has a huge value for `decimals`
+	// and that would overflow the Token entity's i32 field for the decimals
+	if (decimalsResult.value.toBigDecimal().gt(BigDecimal.fromString("255"))) {
+		return MAX_DECIMALS;
+	}
+	return decimalsResult.value.toI32()
 }
 
 export function fetchERC20(address: Address): ERC20Contract {
@@ -56,13 +63,13 @@ export function fetchERC20(address: Address): ERC20Contract {
 		let endpoint         = IERC20.bind(address)
 		let name             = endpoint.try_name()
 		let symbol           = endpoint.try_symbol()
-		let decimals         = endpoint.try_decimals()
+		let decimals         = fetchERC20Decimals(endpoint)
 
 		// Common
 		contract             = new ERC20Contract(address)
 		contract.name        = name.reverted     ? null : name.value
 		contract.symbol      = symbol.reverted   ? null : symbol.value
-		contract.decimals    = decimals.reverted ? DEFAULT_DECIMALS   : normalizeDecimals(decimals.value)
+		contract.decimals    = decimals
 		contract.totalSupply = fetchERC20Balance(contract as ERC20Contract, null).id
 		contract.asAccount   = address
 		contract.save()

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -18,7 +18,7 @@ dataSources:
         - ERC20Contract
       abis:
         - name: IERC20
-          file: ./node_modules/@openzeppelin/contracts/build/contracts/IERC20Metadata.json
+          file: ./abis/IERC20Metadata.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer


### PR DESCRIPTION
# Description
Fix erc20 contracts decimals overflow. The problem cause by try_decimals() function of IERC20Metadata abis, it cannot handle decimals bigger than uint8, this make crash when indexing subgraph. I fix this issue by change type of decimal to uint256 and make a check decimals function in mapping file, this is more safer than use uint8 type directly for decimals (The check decimals function we use from this: https://github.com/georgeroman/erc20-subgraph/blob/main/src/mapping.ts)

Fixes #3

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Evidence**:

https://github.com/user-attachments/assets/15353c0c-a58e-4209-b4a4-3f77643643d6


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
